### PR TITLE
Add `contextualData` to #request-generate

### DIFF
--- a/draft-ietf-protected-audience-key-value-services.md
+++ b/draft-ietf-protected-audience-key-value-services.md
@@ -367,7 +367,7 @@ values are strings.
   1. `id`, which is an identifier indicates a partition in the
      compression group.
 * a `compression groups`, which is a list of `group`s, each
-with the following parameters:
+  with the following parameters:
  * a `compression group id` integer identifier of this compression
    group.
  * a `partitions`, which is a list of `partition`s belonging to this compression

--- a/draft-ietf-protected-audience-key-value-services.md
+++ b/draft-ietf-protected-audience-key-value-services.md
@@ -358,13 +358,13 @@ This algorithm takes as input:
 * an [HPKE] `public key`.
 * a `key id` integer associated with `public key`.
 * a `metadata` map for global configuration, where both keys and
-values are strings.
+  values are strings.
 * a `contextual data` map for contextual signals configuration,
   where keys are strings, and values are lists of `index`. Each
   `index` has the following parameters:
-  1. `compression group id`, which is an identifier indicates a
+  * `compression group id`, which is an identifier indicates a
      compression group.
-  1. `id`, which is an identifier indicates a partition in the
+  * `id`, which is an identifier indicates a partition in the
      compression group.
 * a `compression groups`, which is a list of `group`s, each
   with the following parameters:

--- a/draft-ietf-protected-audience-key-value-services.md
+++ b/draft-ietf-protected-audience-key-value-services.md
@@ -384,32 +384,32 @@ The output is an [HPKE] ciphertext encrypted `request` and a context
 1. Let `partitions` be an empty array.
 1. Let `perPartitionMetadata` be an empty map.
 1. For each `group` in `compression groups`:
-  1. For each `partition` in `group`'s `partitions`:
-    1. Let `p` be an empty map.
-    1. Set `p["compressionGroupId"]` to `group`'s `compression group id`.
-    1. Set `p["id"]` to `partition`'s `id`.
-    1. Set `p["metadata"]` to `partition`'s `metadata`.
-    1. Let `arguments` be an empty array.
-    1. For each `tag` → `value` in `partition`'s `namespace`:
-      1. If `tag` is one of {{tags}}:
-        1. Let `argument` be an empty map.
-        1. Set `argument["tags"]` to [`tag`].
-        1. Set `argument["data"]` to `value`.
-        1. Insert `argument` into `arguments`.
-    1. Set `p["arguments"]` to `arguments`.
-    1. Insert `p` into `partitions`.
+    1. For each `partition` in `group`'s `partitions`:
+        1. Let `p` be an empty map.
+        1. Set `p["compressionGroupId"]` to `group`'s `compression group id`.
+        1. Set `p["id"]` to `partition`'s `id`.
+        1. Set `p["metadata"]` to `partition`'s `metadata`.
+        1. Let `arguments` be an empty array.
+        1. For each `tag` → `value` in `partition`'s `namespace`:
+            1. If `tag` is one of {{tags}}:
+                1. Let `argument` be an empty map.
+                1. Set `argument["tags"]` to [`tag`].
+                1. Set `argument["data"]` to `value`.
+                1. Insert `argument` into `arguments`.
+        1. Set `p["arguments"]` to `arguments`.
+        1. Insert `p` into `partitions`.
 1. Let `contextualData` be an empty array.
 1. For each `signal` → `indices` in `contextual data`:
-   1. Let `data` be an empty map.
-   1. Let `ids` be an empty array.
-   1. For each `index` in `indices`:
-      1. Let `idPair` be an empty array.
-      1. Append `index`'s `compression group id` to `idPair`.
-      1. Append `index`'s `id` to `idPair`.
-      1. Append `idPair` to `ids`.
-   1. Set `data["ids"]` to `ids`.
-   1. Set `data["value"]` to `signal`.
-   1. Append `data` to `contextualData`.
+    1. Let `data` be an empty map.
+    1. Let `ids` be an empty array.
+    1. For each `index` in `indices`:
+        1. Let `idPair` be an empty array.
+        1. Append `index`'s `compression group id` to `idPair`.
+        1. Append `index`'s `id` to `idPair`.
+        1. Append `idPair` to `ids`.
+    1. Set `data["ids"]` to `ids`.
+    1. Set `data["value"]` to `signal`.
+    1. Append `data` to `contextualData`.
 1. Set `perPartitionMetadata["contextualData"]` to `contextualData`.
 1. Set `requestMap["metadata"]` to `metadata`.
 1. Set `requestMap["partitions"]` to `partitions`.


### PR DESCRIPTION
1. Add `perPartitionMetadata` to `requestMap`.
2. Add `contextualData` to `perPartitionMetadata`.
3. Align naming rules:
  * Use lower case with space for pass-in arguments.
  * Use camel case for variables in request generation.